### PR TITLE
Potential fix for code scanning alert no. 17: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -1,4 +1,6 @@
 name: MkDocs
+permissions:
+  contents: write
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bengarrett/RetroTxt/security/code-scanning/17](https://github.com/bengarrett/RetroTxt/security/code-scanning/17)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Since the workflow deploys documentation using MkDocs, it likely requires `contents: write` to push changes to GitHub Pages. We will explicitly set this permission while ensuring no unnecessary permissions are granted.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
